### PR TITLE
Unable to initialize replicaset with mongo driver 1.8.0

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -78,7 +78,7 @@ class Chef::ResourceDefinitionList::MongoDB
       Chef::Log.info("Initiating replicaset")
       retries = 10
       begin
-        connection = Mongo::Connection.new([host_members.first])
+        connection = Mongo::Connection.new(members.first['fqdn'], members.first['mongodb']['port'])
       rescue Mongo::ConnectionFailure
         if (retries > 0)
           Chef::Log.warn("Unable to connect to #{host_members.first}, retrying ...")
@@ -175,7 +175,7 @@ class Chef::ResourceDefinitionList::MongoDB
 
       retries = 5
       begin
-        testconn = Mongo::Connection.new([node.fqdn])
+        testconn = Mongo::Connection.new(node.fqdn, node['mongodb']['port'])
       rescue Mongo::ConnectionFailure
         if (retries > 0)
           Chef::Log.warn("Unable to connect to #{node.fqdn}, retrying in 20 seconds ...")


### PR DESCRIPTION
I just tried your rewrite of the replicaset configuration, but it does not work for me.

```
WARN: Unable to connect to myhost:27017. Mongo::MongoClient.new host or port argument error, host:["myhost:27017"], port:nil
```

I think the problem is that the latest driver (1.8.0) complains about invalid arguments for the connection initializer. The older drivers (<1.8.0) silently use the default `localhost:27017`, which works but may not be intended...
